### PR TITLE
JDP201003-38 Exception Handler

### DIFF
--- a/src/main/java/com/kodilla/ecommerce/exception/handler/ApiError.java
+++ b/src/main/java/com/kodilla/ecommerce/exception/handler/ApiError.java
@@ -1,0 +1,27 @@
+package com.kodilla.ecommerce.exception.handler;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApiError {
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
+    private LocalDateTime timestamp;
+    private HttpStatus status;
+    private String message;
+    private String debugMessage;
+
+    public ApiError(HttpStatus status, String message, Throwable ex) {
+        timestamp = LocalDateTime.now();
+        this.status = status;
+        this.message = message;
+        this.debugMessage = ex.getLocalizedMessage();
+    }
+}

--- a/src/main/java/com/kodilla/ecommerce/exception/handler/RestExceptionHandler.java
+++ b/src/main/java/com/kodilla/ecommerce/exception/handler/RestExceptionHandler.java
@@ -1,0 +1,53 @@
+package com.kodilla.ecommerce.exception.handler;
+
+import com.kodilla.ecommerce.exception.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class RestExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(RestExceptionHandler.class);
+
+    @ExceptionHandler({NotFoundException.class})
+    public ResponseEntity<ApiError> handleBookExistException(NotFoundException ex) {
+        return handleException(ex);
+    }
+
+    @ExceptionHandler({NotValidException.class})
+    public ResponseEntity<ApiError> handleBookNotFoundException(NotValidException ex) {
+        return handleException(ex);
+    }
+
+    @ExceptionHandler({ProductAlreadyExistException.class})
+    public ResponseEntity<ApiError> handleCopyExistException(ProductAlreadyExistException ex) {
+        return handleException(ex);
+    }
+
+    @ExceptionHandler({UserAlreadyBlockedException.class})
+    public ResponseEntity<ApiError> handleCopyNotFoundException(UserAlreadyBlockedException ex) {
+        return handleException(ex);
+    }
+
+    @ExceptionHandler({UserAlreadyExists.class})
+    public ResponseEntity<ApiError> handleCopyIsBorrowedException(UserAlreadyExists ex) {
+        return handleException(ex);
+    }
+
+    @ExceptionHandler({UserIsNotBlockedException.class})
+    public ResponseEntity<ApiError> handleRentalExistException(UserIsNotBlockedException ex) {
+        return handleException(ex);
+    }
+
+    private ResponseEntity<ApiError> handleException(RuntimeException ex) {
+        String message = ex.getMessage();
+        logger.error("ErrorMessage: {} , exceptionBody: {}", message, ex);
+        final ApiError apiError = new ApiError(HttpStatus.BAD_REQUEST, message, ex);
+        return new ResponseEntity<>(apiError, apiError.getStatus());
+    }
+}

--- a/src/main/java/com/kodilla/ecommerce/exception/handler/RestExceptionHandler.java
+++ b/src/main/java/com/kodilla/ecommerce/exception/handler/RestExceptionHandler.java
@@ -15,32 +15,32 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     private static final Logger logger = LoggerFactory.getLogger(RestExceptionHandler.class);
 
     @ExceptionHandler({NotFoundException.class})
-    public ResponseEntity<ApiError> handleBookExistException(NotFoundException ex) {
+    public ResponseEntity<ApiError> handleNotFoundException(NotFoundException ex) {
         return handleException(ex);
     }
 
     @ExceptionHandler({NotValidException.class})
-    public ResponseEntity<ApiError> handleBookNotFoundException(NotValidException ex) {
+    public ResponseEntity<ApiError> handleNotValidException(NotValidException ex) {
         return handleException(ex);
     }
 
     @ExceptionHandler({ProductAlreadyExistException.class})
-    public ResponseEntity<ApiError> handleCopyExistException(ProductAlreadyExistException ex) {
+    public ResponseEntity<ApiError> handleProductAlreadyExistException(ProductAlreadyExistException ex) {
         return handleException(ex);
     }
 
     @ExceptionHandler({UserAlreadyBlockedException.class})
-    public ResponseEntity<ApiError> handleCopyNotFoundException(UserAlreadyBlockedException ex) {
+    public ResponseEntity<ApiError> handleAlreadyBlockedException(UserAlreadyBlockedException ex) {
         return handleException(ex);
     }
 
     @ExceptionHandler({UserAlreadyExists.class})
-    public ResponseEntity<ApiError> handleCopyIsBorrowedException(UserAlreadyExists ex) {
+    public ResponseEntity<ApiError> handleUserAlreadyExists(UserAlreadyExists ex) {
         return handleException(ex);
     }
 
     @ExceptionHandler({UserIsNotBlockedException.class})
-    public ResponseEntity<ApiError> handleRentalExistException(UserIsNotBlockedException ex) {
+    public ResponseEntity<ApiError> handleUserIsNotBlockedException(UserIsNotBlockedException ex) {
         return handleException(ex);
     }
 


### PR DESCRIPTION
W razie wywołania exception stworzonego przez nas, zwraca status 400 bad request zamiast 500 internal server error.

przykład:
{
"timestamp": "20-11-2020 02:57:49",
"status": "BAD_REQUEST",
"message": "User with id: 444 does not exist",
"debugMessage": "User with id: 444 does not exist"
}